### PR TITLE
コミット収集方法の変更

### DIFF
--- a/api/client/git_client.py
+++ b/api/client/git_client.py
@@ -1,10 +1,9 @@
 import requests
 import sys
 import datetime
-import base64
 from typing import NamedTuple
 from typing import NamedTuple
-from utils import log_info
+from utils import log_error
 
 sys.path.append("../")
 from config import constants
@@ -21,11 +20,23 @@ class Diff(NamedTuple):
 
 class GitClient:
     def __init__(self, user_name: str):
-        self.user_name = user_name
         self.__headers = {
             "Authorization": f"token {constants.ACCESS_TOKEN}",
             "Accept": "application/vnd.github.v3+json",
         }
+        self.user_name = user_name
+        self.display_name = self.__get_user_display_name()
+
+    # ユーザのdisplayNameを取得する
+    def __get_user_display_name(self):
+        response = requests.get(
+            constants.GIT_USER_URL(self.user_name), headers=self.__headers
+        )
+
+        if response.status_code == 200:
+            return response.json()["name"]
+        else:
+            log_error("対象ユーザが見つかりませんでした。：", self.user_name)
 
     # ユーザの全リポジトリを取得する
     def get_repos_list(self) -> list:
@@ -36,6 +47,17 @@ class GitClient:
             return response.json()
         else:
             print("対象ユーザのリポジトリが見つかりませんでした．:", self.user_name)
+            return []
+
+    # ユーザの全イベントを取得する
+    def get_events(self) -> list:
+        response = requests.get(
+            constants.GIT_EVENTS_URL(self.user_name), headers=self.__headers
+        )
+        if response.status_code == 200:
+            return response.json()
+        else:
+            log_error("対象ユーザのイベントが見つかりませんでした。：", self.user_name)
             return []
 
     # リポジトリの全コミットを取得する
@@ -89,62 +111,119 @@ class GitClient:
             return []
 
     # ユーザの前回更新時までのdiffを全て取得する
-    def get_commits_diff(self, last_date: str, current_date: str) -> list:
-        repos_list = self.get_repos_list()
-        repo_commit_list = []
-        for repo in repos_list:
-            repo_name = repo["name"]
-            params = {
-                "since": last_date.isoformat(),
-                "until": current_date.isoformat(),
-                "per_page": 100,
-            }
+    def get_commits_diff(self, last_date: str) -> list:
+        events_list = self.get_events()
+        commit_list = []
+        for event in events_list:
+            # 現段階ではプッシュイベントのみを対象にする
+            if event["type"] == "PushEvent":
+                date_str = event["created_at"]
+                date = datetime.datetime.strptime(
+                        date_str, "%Y-%m-%dT%H:%M:%SZ"
+                )
+                if date <= last_date:
+                    break
 
-            response = requests.get(
-                constants.GIT_COMMITS_URL(self.user_name, repo_name),
-                params=params,
-                headers=self.__headers,
-            )
-
-            if response.status_code == 200:
-                commits_data = response.json()
-                if not commits_data:
+                commits = event["payload"]["commits"]
+                if not commits:
                     continue
+                for commit in commits:
+                    author = commit["author"]["name"]
+                    # コミット作成者がユーザ名と一致している時のみ判定
+                    if author == self.user_name or author == self.display_name:
+                        # コミットメッセージにmergeが含まれていたらマージコミットと判断してスキップ
+                        if "merge" in commit["message"].lower():
+                            continue
 
-                commit_list = []
-                for commit in commits_data:
-                    utc_date_str = commit["commit"]["author"]["date"]
-                    utc_date = datetime.datetime.strptime(
-                        utc_date_str, "%Y-%m-%dT%H:%M:%SZ"
-                    )
-                    jst_offset = datetime.timedelta(hours=9)
+                        response = requests.get(commit["url"], headers=self.__headers)
+                        if response.status_code == 200:
+                            commit_data = response.json()
+                            diffs = commit_data["files"]
+                            parents = commit_data["parents"]
+                            parent_hash = ""
+                            if len(parents) > 0:
+                                parent_hash = parents[0]["sha"]
 
-                    parent_hash = ""
-                    if len(commit["parents"]) > 0:
-                        parent_hash = commit["parents"][0]["sha"]
-
-                    diff_response = requests.get(commit["url"], headers=self.__headers)
-                    if diff_response.status_code == 200:
-                        diffs = diff_response.json()["files"]
-                        diff_list = []
-                        for diff in diffs:
-                            diff_list.append(
-                                Diff(
-                                    diff["filename"],
-                                    diff["additions"],
-                                    diff["deletions"],
-                                    utc_date + jst_offset,
-                                    commit["sha"],
-                                    parent_hash,
+                            diff_list = []
+                            for diff in diffs:
+                                diff_list.append(
+                                    Diff(
+                                        diff["filename"],
+                                        diff["additions"],
+                                        diff["deletions"],
+                                        date,
+                                        commit["sha"],
+                                        parent_hash,
+                                    )
                                 )
-                            )
-                        commit_list.append(diff_list)
-                    else:
-                        return []
-                repo_commit_list += commit_list
-            else:
-                return []
-        return repo_commit_list
+                            commit_list.append(diff_list)
+                        else:
+                            return []
+
+        return commit_list
+
+
+
+
+
+
+    # # ユーザの前回更新時までのdiffを全て取得する
+    # def get_commits_diff(self, last_date: str, current_date: str) -> list:
+    #     repos_list = self.get_repos_list()
+    #     repo_commit_list = []
+    #     for repo in repos_list:
+    #         repo_name = repo["name"]
+    #         params = {
+    #             "since": last_date.isoformat(),
+    #             "until": current_date.isoformat(),
+    #             "per_page": 100,
+    #         }
+
+    #         response = requests.get(
+    #             constants.GIT_COMMITS_URL(self.user_name, repo_name),
+    #             params=params,
+    #             headers=self.__headers,
+    #         )
+
+    #         if response.status_code == 200:
+    #             commits_data = response.json()
+    #             if not commits_data:
+    #                 continue
+
+    #             commit_list = []
+    #             for commit in commits_data:
+    #                 utc_date_str = commit["commit"]["author"]["date"]
+    #                 utc_date = datetime.datetime.strptime(
+    #                     utc_date_str, "%Y-%m-%dT%H:%M:%SZ"
+    #                 )
+    #                 jst_offset = datetime.timedelta(hours=9)
+
+    #                 parent_hash = ""
+    #                 if len(commit["parents"]) > 0:
+    #                     parent_hash = commit["parents"][0]["sha"]
+
+    #                 diff_response = requests.get(commit["url"], headers=self.__headers)
+    #                 if diff_response.status_code == 200:
+    #                     diffs = diff_response.json()["files"]
+    #                     diff_list = []
+    #                     for diff in diffs:
+    #                         diff_list.append(
+    #                             Diff(
+    #                                 diff["filename"],
+    #                                 diff["additions"],
+    #                                 diff["deletions"],
+    #                                 utc_date + jst_offset,
+    #                                 commit["sha"],
+    #                                 parent_hash,
+    #                             )
+    #                         )
+    #                     commit_list.append(diff_list)
+    #                 else:
+    #                     return []
+    #             repo_commit_list += commit_list
+    #         else:
+    #             return []
+    #     return repo_commit_list
 
     # 最終餌やり日から5日間の間にコミットしているかを判定
     def exist_5days_commits(self, last_date: str, current_date: str) -> bool:

--- a/api/config/constants.py
+++ b/api/config/constants.py
@@ -7,14 +7,18 @@ load_dotenv()
 # URL
 GIT_BASE_URL = "https://api.github.com/"
 
+
 def GIT_USER_URL(user_name: str):
     return GIT_BASE_URL + "users/" + user_name
+
 
 def GIT_REPOS_URL(user_name: str):
     return GIT_BASE_URL + "users/" + user_name + "/repos"
 
+
 def GIT_EVENTS_URL(user_name: str):
     return GIT_BASE_URL + "users/" + user_name + "/events"
+
 
 def GIT_COMMITS_URL(user_name: str, repo_name: str):
     return GIT_BASE_URL + "repos/" + user_name + "/" + repo_name + "/commits"

--- a/api/config/constants.py
+++ b/api/config/constants.py
@@ -7,10 +7,14 @@ load_dotenv()
 # URL
 GIT_BASE_URL = "https://api.github.com/"
 
+def GIT_USER_URL(user_name: str):
+    return GIT_BASE_URL + "users/" + user_name
 
 def GIT_REPOS_URL(user_name: str):
     return GIT_BASE_URL + "users/" + user_name + "/repos"
 
+def GIT_EVENTS_URL(user_name: str):
+    return GIT_BASE_URL + "users/" + user_name + "/events"
 
 def GIT_COMMITS_URL(user_name: str, repo_name: str):
     return GIT_BASE_URL + "repos/" + user_name + "/" + repo_name + "/commits"

--- a/api/stats/metrics.py
+++ b/api/stats/metrics.py
@@ -6,7 +6,7 @@ sys.path.append("../")
 
 from client import GitClient
 from config import constants
-from utils import extract_extension, what_time
+from utils import extract_extension, what_time, log_info
 
 
 class Metrics(NamedTuple):
@@ -56,12 +56,14 @@ class MetricsManager:
 
         # feedの処理
         if current_met:
-            diffs = git_client.get_commits_diff(current_met.last_date, current_date)
+            diffs = git_client.get_commits_diff(current_met.last_date)
             current_level = current_met.level
             current_exp = current_met.exp
             code_score = current_met.code_score * current_met.commits_count
             change_files = current_met.change_files * current_met.commits_count
             sorted_diffs = sorted(diffs, key=lambda x: x[0].date)
+            log_info(sorted_diffs)
+            log_info(current_met.last_date)
 
             for index, files in enumerate(sorted_diffs):
                 f_met = self.__get_files_metrics(files)


### PR DESCRIPTION
## 詳細
- これまでコミット収集に全リポジトリで期間内のコミットを収集していたが，/eventsでイベントを収集してきて，プッシュイベントからコミットを収集する方法に変更(結構早くなる)
## 確認項目
- [x] /feedでexpが更新される
- [x] exists_5days_commitsが実行されている（スケジューラの期間を短くして確認）