### PR TITLE
ご飯ボタンをおしてから離脱した時、戻ってきたら初期アニメーションから始まるようにする

### DIFF
--- a/frontend/src/contents/components/dino-home/dino-home.tsx
+++ b/frontend/src/contents/components/dino-home/dino-home.tsx
@@ -30,13 +30,15 @@ export const DinoHome = () => {
       dinoBehavior: state.dinoBehavior,
       dinoStatus: state.dinoStatus,
       visibility: state.visibility,
+      restartAnimation: state.restartAnimation,
+      stopAnimation: state.stopAnimation,
       setServing: state.setServing,
       setDinoBehavior: state.setDinoBehavior,
       setDinoStatus: state.setDinoStatus,
       setVisibility: state.setVisibility,
     }))
   );
-  const { serving, dinoBehavior, dinoStatus, visibility, setDinoBehavior, setVisibility } = store;
+  const { serving, dinoBehavior, dinoStatus, visibility, restartAnimation, stopAnimation } = store;
 
   /**
    * Handlers
@@ -54,25 +56,28 @@ export const DinoHome = () => {
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'hidden') {
-        setVisibility('hidden');
-        setDinoBehavior({
-          animation: 'stop',
-        });
+        stopAnimation();
       } else if (document.visibilityState === 'visible') {
-        setDinoBehavior({
-          startPos: 0,
-          direction: 'right',
-          animation: 'walking',
-          state: 'walk',
-        });
-        setVisibility('visible');
+        restartAnimation();
       }
     };
 
+    const handleFocus = () => {
+      restartAnimation();
+    };
+
+    const handleBlur = () => {
+      stopAnimation();
+    };
+
     document.addEventListener('visibilitychange', handleVisibilityChange);
+    document.addEventListener('focus', handleFocus);
+    document.addEventListener('blur', handleBlur);
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
+      document.removeEventListener('focus', handleFocus);
+      document.removeEventListener('blur', handleBlur);
     };
   }, []);
 

--- a/frontend/src/contents/components/dino-home/hooks/use-dino-home-handler.ts
+++ b/frontend/src/contents/components/dino-home/hooks/use-dino-home-handler.ts
@@ -1,7 +1,7 @@
 import * as feedAPI from '@/contents/api/feed';
 import type { Actions, State } from '@/contents/store/use-page-store';
 import { getCurrentDinoPosition, getUserName, wait } from '@/contents/utils';
-import { type AnimationEventHandler, type RefObject, useCallback } from 'react';
+import { type AnimationEventHandler, type RefObject, useCallback, useEffect } from 'react';
 
 export type Mutations = Pick<Actions, 'setServing' | 'setDinoBehavior' | 'setDinoStatus'>;
 export type HandlerArgs = {

--- a/frontend/src/contents/store/use-page-store.ts
+++ b/frontend/src/contents/store/use-page-store.ts
@@ -14,6 +14,8 @@ export type State = {
 
 export type Actions = {
   initializeState: () => void;
+  restartAnimation: () => void;
+  stopAnimation: () => void;
   setDinoStatus: (status: Partial<DinoStatus>) => void;
   setIsRestarted: (isRestarted: boolean) => void;
   setDinoBehavior: (behavior: Partial<DinoBehavior>) => void;
@@ -48,6 +50,19 @@ export const usePageStore = create<State & Actions>()(
         state.splitting = initialState.splitting;
         state.visibility = initialState.visibility;
         state.isRestarted = initialState.isRestarted;
+      });
+    },
+    restartAnimation: () => {
+      set((state) => {
+        state.serving = false;
+        state.visibility = 'visible';
+        state.dinoBehavior = initialState.dinoBehavior;
+      });
+    },
+    stopAnimation: () => {
+      set((state) => {
+        state.dinoBehavior.animation = 'stop';
+        state.visibility = 'hidden';
       });
     },
     setDinoStatus: (status) => {

--- a/frontend/src/contents/utils/wait.test.ts
+++ b/frontend/src/contents/utils/wait.test.ts
@@ -11,4 +11,6 @@ describe('wait', () => {
     expect(setTimeoutMock).toHaveBeenCalledTimes(1);
     expect(setTimeoutMock).toHaveBeenLastCalledWith(expect.any(Function), delay);
   });
+
+  test.todo('wait中に離脱した場合、エラーをthrowする');
 });

--- a/frontend/src/contents/utils/wait.ts
+++ b/frontend/src/contents/utils/wait.ts
@@ -1,2 +1,32 @@
-export const wait = async (millisec: number) =>
-  await new Promise((resolve) => setTimeout(resolve, millisec));
+/**
+ * wait関数
+ * 指定の秒数待つが、その間に離脱した場合rejectする。
+ */
+export const wait = async (millisec: number) => {
+  let timeoutId: NodeJS.Timeout;
+  let visibilityListener: () => void;
+
+  const waitForVisibilityChange = () => {
+    return new Promise<void>((_resolve, reject) => {
+      visibilityListener = () => {
+        if (document.visibilityState === 'hidden') {
+          clearTimeout(timeoutId);
+          reject(new Error('Page became hidden before timeout'));
+        }
+      };
+      document.addEventListener('visibilitychange', visibilityListener);
+    });
+  };
+
+  const waitTimeout = () => {
+    return new Promise<void>((resolve) => {
+      timeoutId = setTimeout(resolve, millisec);
+    });
+  };
+
+  try {
+    await Promise.race([waitForVisibilityChange(), waitTimeout()]);
+  } finally {
+    document.removeEventListener('visibilitychange', visibilityListener);
+  }
+};


### PR DESCRIPTION
close #13 

`wait`中に離脱した場合、throwしてcatch節に入り残りの処理をスキップするようにした

のちにリファクタリングしたい（関数名含め）

## 下記のそれぞれが問題ないことを確認（逆にprod環境のは全部変な挙動になることも確認）

- [x] feedボタンを押してすぐ離脱
- [x] bend中に離脱
- [x] eat中に離脱